### PR TITLE
feat: 🧪 add Bats tests for `cli-tips.sh`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Run Bats Tests
+
+# Trigger the workflow on push events to cli-tips.sh
+on:
+  push:
+    paths:
+      - "cli-tips.sh"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: 🧪 Run Bats Tests
+        run: npx bats test/cli-tips.bats

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
   },
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[bats]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format"
   }
 }

--- a/test/cli-tips.bats
+++ b/test/cli-tips.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+setup() {
+    # Create a temporary directory for TIPS_FOLDER
+    export TIPS_FOLDER="$(mktemp -d)"
+
+    # Create sample tips files
+    echo -e "Tip 1 in English\nTip 2 in English" >"$TIPS_FOLDER/en.txt"
+    echo -e "Consejo 1 en Español\nConsejo 2 en Español" >"$TIPS_FOLDER/es.txt"
+
+    # Path to the script being tested
+    SCRIPT_PATH="./cli-tips.sh"
+}
+
+teardown() {
+    # Remove the temporary TIPS_FOLDER
+    rm -rf "$TIPS_FOLDER"
+}
+
+@test "Displays help with -h option" {
+    run "$SCRIPT_PATH" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "Displays help with --help option" {
+    run "$SCRIPT_PATH" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "Errors on unknown option" {
+    run "$SCRIPT_PATH" --unknown
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown option: --unknown"* ]]
+}
+
+@test "Prints a tip in default language" {
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "Tip "* ]]
+}
+
+@test "Prints a tip in specified language" {
+    run "$SCRIPT_PATH" --language es
+    [ "$status" -eq 0 ]
+    [[ "$output" == "Consejo "* ]]
+}
+
+@test "Filters tips with --about keyword" {
+    # Add a tip containing the keyword 'git' to the English tips
+    echo -e "Tip about git" >>"$TIPS_FOLDER/en.txt"
+
+    run "$SCRIPT_PATH" --about git
+    [ "$status" -eq 0 ]
+    [[ "$output" == "Tip about git" ]]
+}
+
+@test "Filters tips with --about keyword and --language option" {
+    # Add a tip containing the keyword 'git' to the English tips
+    echo -e "Consejo sobre git" >>"$TIPS_FOLDER/es.txt"
+
+    run "$SCRIPT_PATH" --about git --language es
+    [ "$status" -eq 0 ]
+    [[ "$output" == "Consejo sobre git" ]]
+}
+
+@test "Exits if no matching tips are found" {
+    run "$SCRIPT_PATH" --about nonexistent
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "Uses default language if specified language file is missing" {
+    rm "$TIPS_FOLDER/es.txt"
+    run "$SCRIPT_PATH" --language es
+    [ "$status" -eq 0 ]
+    [[ "$output" == "Tip "* ]]
+}
+
+@test "Errors if no language is specified after --language option" {
+    run "$SCRIPT_PATH" --language
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Error: No language specified"* ]]
+}
+
+@test "Handles missing TIPS_FOLDER gracefully" {
+    rm -rf "$TIPS_FOLDER"
+    run "$SCRIPT_PATH"
+    [ "$status" -ne 0 ]
+}
+
+@test "Handles empty tips file gracefully" {
+    echo -n "" >"$TIPS_FOLDER/en.txt"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow to run Bats tests on `cli-tips.sh`.
- Created a comprehensive Bats test suite to validate functionality, including:
  * Help options (`-h` and `--help`)
  * Language-specific tips
  * Error handling for unknown options and missing files and etc.
- Updated VSCode settings to set a formatter for `.bats` files